### PR TITLE
Fix NPE issue when onfido claim mapping is not provided.

### DIFF
--- a/components/org.wso2.carbon.identity.verification.onfido.connector/src/main/java/org/wso2/carbon/identity/verification/onfido/connector/OnfidoIdentityVerifier.java
+++ b/components/org.wso2.carbon.identity.verification.onfido.connector/src/main/java/org/wso2/carbon/identity/verification/onfido/connector/OnfidoIdentityVerifier.java
@@ -53,6 +53,7 @@ import static org.wso2.carbon.extension.identity.verification.mgt.utils.Identity
 import static org.wso2.carbon.identity.verification.onfido.connector.constants.OnfidoConstants.APPLICANT_ID;
 import static org.wso2.carbon.identity.verification.onfido.connector.constants.OnfidoConstants.BASE_URL;
 import static org.wso2.carbon.identity.verification.onfido.connector.constants.OnfidoConstants.ErrorMessage.ERROR_APPLICANT_ID_NOT_FOUND;
+import static org.wso2.carbon.identity.verification.onfido.connector.constants.OnfidoConstants.ErrorMessage.ERROR_CLAIM_MAPPING_NOT_FOUND;
 import static org.wso2.carbon.identity.verification.onfido.connector.constants.OnfidoConstants.ErrorMessage.ERROR_CLAIM_VALUE_NOT_EXIST;
 import static org.wso2.carbon.identity.verification.onfido.connector.constants.OnfidoConstants.ErrorMessage.ERROR_GETTING_ONFIDO_WORKFLOW_STATUS;
 import static org.wso2.carbon.identity.verification.onfido.connector.constants.OnfidoConstants.ErrorMessage.ERROR_IDV_PROVIDER_CONFIG_PROPERTIES_EMPTY;
@@ -537,6 +538,10 @@ public class OnfidoIdentityVerifier extends AbstractIdentityVerifier {
                     if (StringUtils.isEmpty(claimValue)) {
                         throw new IdentityVerificationClientException(ERROR_CLAIM_VALUE_NOT_EXIST.getCode(),
                                 String.format(ERROR_CLAIM_VALUE_NOT_EXIST.getMessage(), claimUri));
+                    }
+                    if (!idVClaimMap.containsKey(claimUri)) {
+                        throw new IdentityVerificationClientException(ERROR_CLAIM_MAPPING_NOT_FOUND.getCode(),
+                                String.format(ERROR_CLAIM_MAPPING_NOT_FOUND.getMessage(), claimUri));
                     }
                     idVProviderClaimWithValueMap.put(idVClaimMap.get(claimUri), claimValue);
                 }

--- a/components/org.wso2.carbon.identity.verification.onfido.connector/src/main/java/org/wso2/carbon/identity/verification/onfido/connector/constants/OnfidoConstants.java
+++ b/components/org.wso2.carbon.identity.verification.onfido.connector/src/main/java/org/wso2/carbon/identity/verification/onfido/connector/constants/OnfidoConstants.java
@@ -162,7 +162,8 @@ public class OnfidoConstants {
                 "found for claim: %s of user: %s."),
         ERROR_DATA_COMPARISON_BREAKDOWN_CLAIM_VERIFICATION_RESULT_NULL("10036", "The Onfido data " +
                 "comparison result returned null for claim: %s of user: %s. This could be due to Comparison Checks " +
-                "not being enabled for your account.");
+                "not being enabled for your account."),
+        ERROR_CLAIM_MAPPING_NOT_FOUND("10037", "No Onfido claim mapping found for the claim URI: %s.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose
- $Subject
- When performing Onfido identity verification for a user, a `NullPointerException` occurs if the Onfido connector is not configured with attribute mapping. This PR addresses the issue by returning a clear and meaningful response stating that the claim mapping is missing.

- Before the fix
<img width="1512" alt="Screenshot 2024-12-30 at 21 40 08" src="https://github.com/user-attachments/assets/f8b4aebc-cabf-40d1-9d5e-c2f56f04ea1b" />

Error log:

```
ERROR {org.wso2.carbon.identity.api.dispatcher.core.DefaultExceptionMapper} - Server encountered an error while serving the request. java.lang.NullPointerException: Null key.
	at org.json.JSONObject.put(JSONObject.java:2050)
	at org.wso2.carbon.identity.verification.onfido.connector.OnfidoIdentityVerifier.getApplicantRequestBody(OnfidoIdentityVerifier.java:745)
	at org.wso2.carbon.identity.verification.onfido.connector.OnfidoIdentityVerifier.createOrUpdateApplicant(OnfidoIdentityVerifier.java:351)
	at org.wso2.carbon.identity.verification.onfido.connector.OnfidoIdentityVerifier.initiateOnfidoVerification(OnfidoIdentityVerifier.java:164)
	at org.wso2.carbon.identity.verification.onfido.connector.OnfidoIdentityVerifier.verifyIdentity(OnfidoIdentityVerifier.java:104)
	at org.wso2.carbon.extension.identity.verification.mgt.IdentityVerificationManagerImpl.verifyIdentity(IdentityVerificationManagerImpl.java:108)
	at org.wso2.carbon.identity.rest.api.user.idv.v1.core.IdentityVerificationService.verifyIdentity(IdentityVerificationService.java:231)
	at org.wso2.carbon.identity.rest.api.user.idv.v1.impl.MeApiServiceImpl.meVerifyIdentity(MeApiServiceImpl.java:62)
	at org.wso2.carbon.identity.rest.api.user.idv.v1.MeApi.meVerifyIdentity(MeApi.java:117)
```

- After the fix
<img width="1512" alt="Screenshot 2024-12-30 at 20 55 17" src="https://github.com/user-attachments/assets/cbcbb230-5b99-4613-9277-d6feabea1bbe" />


